### PR TITLE
02 memoinput

### DIFF
--- a/memo-app/package-lock.json
+++ b/memo-app/package-lock.json
@@ -15,6 +15,9 @@
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -643,9 +646,17 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       },
@@ -1881,6 +1892,17 @@
         "core-js-compat": "^3.31.0",
         "semver": "^6.3.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
       "engines": {
         "node": ">=6.9.0"
       },

--- a/memo-app/package.json
+++ b/memo-app/package.json
@@ -34,5 +34,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11"
   }
 }

--- a/memo-app/src/App.js
+++ b/memo-app/src/App.js
@@ -1,23 +1,13 @@
-import logo from './logo.svg';
-import './App.css';
+import { useState } from 'react';
+import MemoInput from './MemoInput';
+
 
 function App() {
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.js</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+      <h1>メモアプリ</h1>
+      <MemoInput/>
+
     </div>
   );
 }

--- a/memo-app/src/MemoInput.jsx
+++ b/memo-app/src/MemoInput.jsx
@@ -1,0 +1,25 @@
+import React, {useState} from 'react'
+// useStateを使うことで、関数コンポーネントで状態を持つことができる
+
+const MemoInput = ({onAddMemo}) => { //関数コンポーネントを定義,propsでonAddMemoを受け取る
+  const [input, setInput] = useState(''); // inputの状態を持つ初期値は空文字
+
+  const handleInput = (event) => { // テキストエリアの入力値が変更されたときに呼ばれる関数
+    setInput(event.target.value) // 入力値をinputの状態にセット
+  };
+
+  const handleSubmit = (event) => { // フォームが送信されたときに呼ばれる関数
+    event.preventDefault(); // ページがリロードされるのを防ぐ
+    onAddMemo(input); // onAddMemo関数にinputの状態を渡す
+    setInput(''); // inputの状態をリセット
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <textarea value={input} onChange={handleInput} />
+      <button type="submit">追加</button>
+    </form>
+  );
+}
+
+export default MemoInput


### PR DESCRIPTION
- Memoinputcコンポーネントの作成
- サーバー起動時の警告を処理するための `npm install @babel/plugin-proposal-private-property-in-object --save-dev` を実行しファイルを追加
